### PR TITLE
Fix nutrition error mapping and ReviewMeal image replacement

### DIFF
--- a/backend/src/main/java/com/fitnessapp/backend/api/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/fitnessapp/backend/api/common/GlobalExceptionHandler.java
@@ -154,7 +154,7 @@ public class GlobalExceptionHandler {
             if (message != null) {
                 String normalized = message.toLowerCase();
                 for (String needle : needles) {
-                    if (normalized.contains(needle.toLowerCase())) {
+                    if (normalized.contains(needle)) {
                         return true;
                     }
                 }

--- a/backend/src/main/java/com/fitnessapp/backend/api/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/fitnessapp/backend/api/common/GlobalExceptionHandler.java
@@ -1,5 +1,10 @@
 package com.fitnessapp.backend.api.common;
 
+import java.io.InterruptedIOException;
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -96,21 +101,67 @@ public class GlobalExceptionHandler {
     ) {
         log.error("Food recognition error: {}", ex.getMessage(), ex);
 
-        ErrorCode errorCode;
-        if (ex.getMessage().contains("Rate limit")) {
-            errorCode = ErrorCode.AI_SERVICE_UNAVAILABLE;
-        } else if (ex.getMessage().contains("unavailable")) {
-            errorCode = ErrorCode.AI_SERVICE_UNAVAILABLE;
-        } else if (ex.getMessage().contains("API key expired") || ex.getMessage().contains("API_KEY_INVALID")) {
-            errorCode = ErrorCode.AI_SERVICE_UNAVAILABLE;
-        } else if (ex.getMessage().contains("timeout")) {
-            errorCode = ErrorCode.AI_TIMEOUT;
-        } else {
-            errorCode = ErrorCode.AI_RECOGNITION_FAILED;
-        }
+        ErrorCode errorCode = resolveFoodRecognitionErrorCode(ex);
 
         ApiEnvelope<Void> response = ApiEnvelope.error(errorCode, ex.getMessage(), request.getRequestURI());
         return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
+    }
+
+    private ErrorCode resolveFoodRecognitionErrorCode(FoodRecognitionException ex) {
+        if (hasCause(ex, SocketTimeoutException.class) || chainContains(ex, "timeout", "timed out", "408")) {
+            return ErrorCode.AI_TIMEOUT;
+        }
+
+        if (hasCause(ex, ConnectException.class)
+                || hasCause(ex, SocketException.class)
+                || hasCause(ex, UnknownHostException.class)
+                || hasCause(ex, InterruptedIOException.class)
+                || chainContains(
+                        ex,
+                        "rate limit",
+                        "rate limited",
+                        "429",
+                        "unavailable",
+                        "temporarily unavailable",
+                        "overloaded",
+                        "api key expired",
+                        "api_key_invalid",
+                        "transient gemini api error",
+                        "502",
+                        "503",
+                        "504")) {
+            return ErrorCode.AI_SERVICE_UNAVAILABLE;
+        }
+
+        return ErrorCode.AI_RECOGNITION_FAILED;
+    }
+
+    private boolean hasCause(Throwable throwable, Class<? extends Throwable> type) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (type.isInstance(current)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private boolean chainContains(Throwable throwable, String... needles) {
+        Throwable current = throwable;
+        while (current != null) {
+            String message = current.getMessage();
+            if (message != null) {
+                String normalized = message.toLowerCase();
+                for (String needle : needles) {
+                    if (normalized.contains(needle.toLowerCase())) {
+                        return true;
+                    }
+                }
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     @ExceptionHandler(TimeoutException.class)

--- a/backend/src/main/java/com/fitnessapp/backend/nutrition/service/ai/GeminiMealAnalysisService.java
+++ b/backend/src/main/java/com/fitnessapp/backend/nutrition/service/ai/GeminiMealAnalysisService.java
@@ -150,6 +150,14 @@ public class GeminiMealAnalysisService implements FoodRecognitionProvider {
 
         String contentType = normalizeContentType(image.getContentType());
         if (contentType == null || !SUPPORTED_IMAGE_TYPES.contains(contentType)) {
+            String inferredContentType = inferContentTypeFromFilename(image.getOriginalFilename());
+            if (SUPPORTED_IMAGE_TYPES.contains(inferredContentType)) {
+                log.warn("Falling back to filename-inferred image type '{}' for upload '{}'",
+                        inferredContentType, image.getOriginalFilename());
+                contentType = inferredContentType;
+            }
+        }
+        if (contentType == null || !SUPPORTED_IMAGE_TYPES.contains(contentType)) {
             throw new IllegalArgumentException("Unsupported image type: " + contentType);
         }
 
@@ -321,11 +329,43 @@ public class GeminiMealAnalysisService implements FoodRecognitionProvider {
         }
     }
 
-    private String normalizeContentType(String mediaType) {
+    static String normalizeContentType(String mediaType) {
         if (mediaType == null || mediaType.isBlank()) {
             return null;
         }
-        return mediaType.toLowerCase().trim();
+        String normalized = mediaType.split(";")[0].trim().toLowerCase();
+        return switch (normalized) {
+            case "image/jpg", "image/pjpeg" -> "image/jpeg";
+            case "image/x-png" -> "image/png";
+            default -> normalized;
+        };
+    }
+
+    static String inferContentTypeFromFilename(String filename) {
+        if (filename == null || filename.isBlank()) {
+            return null;
+        }
+
+        String normalized = filename.toLowerCase().trim();
+        if (normalized.endsWith(".jpg") || normalized.endsWith(".jpeg")) {
+            return "image/jpeg";
+        }
+        if (normalized.endsWith(".png")) {
+            return "image/png";
+        }
+        if (normalized.endsWith(".gif")) {
+            return "image/gif";
+        }
+        if (normalized.endsWith(".webp")) {
+            return "image/webp";
+        }
+        if (normalized.endsWith(".heic")) {
+            return "image/heic";
+        }
+        if (normalized.endsWith(".heif")) {
+            return "image/heif";
+        }
+        return null;
     }
 
     // ==================== API Implementation ====================

--- a/backend/src/test/java/com/fitnessapp/backend/api/common/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/fitnessapp/backend/api/common/GlobalExceptionHandlerTest.java
@@ -1,0 +1,67 @@
+package com.fitnessapp.backend.api.common;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fitnessapp.backend.nutrition.exception.FoodRecognitionException;
+
+class GlobalExceptionHandlerTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new TestController())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void mapsRetriedProviderTimeoutsToRequestTimeout() throws Exception {
+        mockMvc.perform(get("/test/timeout"))
+                .andExpect(status().isRequestTimeout())
+                .andExpect(jsonPath("$.code").value(ErrorCode.AI_TIMEOUT.getCode()))
+                .andExpect(jsonPath("$.message").value("All providers failed: Failed after 2 attempt(s)"));
+    }
+
+    @Test
+    void mapsRetriedProviderTransportFailuresToServiceUnavailable() throws Exception {
+        mockMvc.perform(get("/test/unavailable"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.code").value(ErrorCode.AI_SERVICE_UNAVAILABLE.getCode()))
+                .andExpect(jsonPath("$.message").value("All providers failed: Failed after 1 attempt(s)"));
+    }
+
+    @RestController
+    private static final class TestController {
+
+        @GetMapping("/test/timeout")
+        String timeout() {
+            throw new FoodRecognitionException(
+                    "All providers failed: Failed after 2 attempt(s)",
+                    new FoodRecognitionException(
+                            "Failed after 2 attempt(s)",
+                            new SocketTimeoutException("Read timed out")));
+        }
+
+        @GetMapping("/test/unavailable")
+        String unavailable() {
+            throw new FoodRecognitionException(
+                    "All providers failed: Failed after 1 attempt(s)",
+                    new FoodRecognitionException(
+                            "Failed after 1 attempt(s)",
+                            new IOException("Transient Gemini API error: 503")));
+        }
+    }
+}

--- a/backend/src/test/java/com/fitnessapp/backend/nutrition/service/ai/GeminiServiceTest.java
+++ b/backend/src/test/java/com/fitnessapp/backend/nutrition/service/ai/GeminiServiceTest.java
@@ -109,6 +109,24 @@ class GeminiServiceTest {
                 .startsWith((byte) 0xFF, (byte) 0xD8, (byte) 0xFF);
     }
 
+    @Test
+    void testNormalizeContentTypeStripsParametersAndAliasesJpg() {
+        assertThat(GeminiMealAnalysisService.normalizeContentType("image/jpg; charset=binary"))
+                .isEqualTo("image/jpeg");
+        assertThat(GeminiMealAnalysisService.normalizeContentType("image/x-png"))
+                .isEqualTo("image/png");
+    }
+
+    @Test
+    void testInferContentTypeFromFilenameSupportsCommonExtensions() {
+        assertThat(GeminiMealAnalysisService.inferContentTypeFromFilename("meal.HEIC"))
+                .isEqualTo("image/heic");
+        assertThat(GeminiMealAnalysisService.inferContentTypeFromFilename("plate.jpeg"))
+                .isEqualTo("image/jpeg");
+        assertThat(GeminiMealAnalysisService.inferContentTypeFromFilename("unknown.bin"))
+                .isNull();
+    }
+
     private String invokeCompressImage(GeminiMealAnalysisService service, String base64Image, String mediaType)
             throws Exception {
         Method compressImage = GeminiMealAnalysisService.class

--- a/frontend/src/screens/ReviewMealScreen.tsx
+++ b/frontend/src/screens/ReviewMealScreen.tsx
@@ -94,6 +94,76 @@ const isHeicLikeSource = (mimeType?: string | null, path?: string | null): boole
   return HEIC_MIME_TYPES.has(normalizeRouteMimeType(mimeType)) || looksLikeHeicPath(path);
 };
 
+type WebSelectedImage = {
+  uri: string;
+  mimeType?: string;
+  fileName?: string;
+};
+
+const pickWebImageFile = (): Promise<WebSelectedImage | null> => {
+  if (typeof document === 'undefined' || typeof window === 'undefined' || typeof URL === 'undefined') {
+    return Promise.resolve(null);
+  }
+
+  return new Promise((resolve) => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.tabIndex = -1;
+    input.setAttribute('aria-hidden', 'true');
+    input.style.position = 'fixed';
+    input.style.left = '-9999px';
+    input.style.width = '1px';
+    input.style.height = '1px';
+    input.style.opacity = '0';
+    input.style.pointerEvents = 'none';
+
+    let finished = false;
+
+    const cleanup = () => {
+      input.removeEventListener('change', handleChange);
+      window.removeEventListener('focus', handleWindowFocus);
+      if (input.parentNode) {
+        input.parentNode.removeChild(input);
+      }
+    };
+
+    const finish = (value: WebSelectedImage | null) => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      resolve(value);
+    };
+
+    const handleChange = () => {
+      const file = input.files?.[0];
+      if (!file) {
+        finish(null);
+        return;
+      }
+
+      finish({
+        uri: URL.createObjectURL(file),
+        mimeType: file.type || undefined,
+        fileName: file.name || undefined,
+      });
+    };
+
+    const handleWindowFocus = () => {
+      window.setTimeout(() => {
+        if (!finished && !input.files?.length) {
+          finish(null);
+        }
+      }, 300);
+    };
+
+    input.addEventListener('change', handleChange);
+    window.addEventListener('focus', handleWindowFocus);
+    document.body.appendChild(input);
+    input.click();
+  });
+};
+
 export function ReviewMealScreen({ route, navigation }: any) {
   // Support both new image analysis and viewing/editing saved meals
   const { imageUri, imageMimeType, imageFileName, meal, openCamera, imgWcm } = route.params ?? {};
@@ -108,6 +178,7 @@ export function ReviewMealScreen({ route, navigation }: any) {
   const { width: viewportWidth, height: viewportHeight } = useWindowDimensions();
   const queryClient = useQueryClient();
   const hasRequestedCameraPermissionRef = useRef(false);
+  const webObjectUrlRef = useRef<string | null>(null);
   const [loading, setLoading] = useState(!isViewingExisting); // Don't show loading for existing meals
   const [phase, setPhase] = useState<1 | 2 | 3>(1);
   const [items, setItems] = useState<DetectedFood[]>(() => {
@@ -166,6 +237,58 @@ export function ReviewMealScreen({ route, navigation }: any) {
   const hasVisibleTotals = hasMeaningfulNutrition(total);
   const canSaveMeal = hasDetectedResults && hasVisibleTotals;
 
+  const rememberWebObjectUrl = (uri?: string | null) => {
+    if (Platform.OS !== 'web' || typeof URL === 'undefined' || !uri?.startsWith('blob:')) {
+      return;
+    }
+
+    if (webObjectUrlRef.current && webObjectUrlRef.current !== uri) {
+      URL.revokeObjectURL(webObjectUrlRef.current);
+    }
+
+    webObjectUrlRef.current = uri;
+  };
+
+  const prepareSelectedImageForAnalysis = (assetUri: string) => {
+    setLoading(true);
+    setPhase(1);
+    setItems([]);
+    setTotal(null);
+    setSaving(false);
+    setProcessedImageUri(assetUri);
+    setServerImageUrl(undefined);
+    baseNutrition.clear();
+    setShowSuccess(false);
+    successAnim.setValue(0);
+  };
+
+  const applySelectedImage = (asset: { uri: string; mimeType?: string | null; fileName?: string | null }) => {
+    prepareSelectedImageForAnalysis(asset.uri);
+    rememberWebObjectUrl(asset.uri);
+    navigation.setParams({
+      imageUri: asset.uri,
+      imageMimeType: asset.mimeType,
+      imageFileName: asset.fileName,
+      openCamera: false,
+      imgWcm: scaleHintCm,
+    });
+  };
+
+  const handleRetake = () => {
+    if (Platform.OS === 'web') {
+      void openGallery();
+      return;
+    }
+
+    navigation.setParams({
+      openCamera: true,
+      imageUri: undefined,
+      imageMimeType: undefined,
+      imageFileName: undefined,
+      imgWcm: scaleHintCm,
+    });
+  };
+
   // Recalculate total nutrition whenever items change
   useEffect(() => {
     if (items.length === 0) return;
@@ -219,38 +342,43 @@ export function ReviewMealScreen({ route, navigation }: any) {
     Platform.OS === 'web' && !!openCamera && !imageUri && !isViewingExisting
   );
 
+  useEffect(() => {
+    return () => {
+      if (webObjectUrlRef.current && typeof URL !== 'undefined') {
+        URL.revokeObjectURL(webObjectUrlRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (Platform.OS !== 'web') {
+      return;
+    }
+
+    setShowWebPermissionModal(!!openCamera && !imageUri && !isViewingExisting);
+  }, [imageUri, isViewingExisting, openCamera]);
+
   const handleWebPermissionAllow = async () => {
     setShowWebPermissionModal(false);
     try {
-      const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ['images'],
-        allowsEditing: true,
-        aspect: [4, 3],
-        quality: 0.82,
-      });
-
-      if (result.canceled || !result.assets?.[0]?.uri) {
+      const asset = await pickWebImageFile();
+      if (!asset?.uri) {
+        navigation.setParams({ openCamera: false });
         setLoading(false);
-        if (navigation.canGoBack()) navigation.goBack();
         return;
       }
 
-      navigation.setParams({
-        imageUri: result.assets[0].uri,
-        imageMimeType: result.assets[0].mimeType,
-        imageFileName: result.assets[0].fileName,
-        openCamera: false,
-      });
+      applySelectedImage(asset);
     } catch {
+      navigation.setParams({ openCamera: false });
       setLoading(false);
-      if (navigation.canGoBack()) navigation.goBack();
     }
   };
 
   const handleWebPermissionCancel = () => {
     setShowWebPermissionModal(false);
+    navigation.setParams({ openCamera: false });
     setLoading(false);
-    if (navigation.canGoBack()) navigation.goBack();
   };
 
   useEffect(() => {
@@ -314,6 +442,7 @@ export function ReviewMealScreen({ route, navigation }: any) {
 
     // Wait until we have an image URI (camera capture / gallery pick)
     if (!imageUri) {
+      setLoading(false);
       return;
     }
 
@@ -501,32 +630,34 @@ export function ReviewMealScreen({ route, navigation }: any) {
 
   const openGallery = async () => {
     try {
-      if (Platform.OS !== 'web') {
-        const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
-        if (status !== 'granted') {
-          Alert.alert('Permission needed', 'Gallery permission is required');
+      if (Platform.OS === 'web') {
+        const asset = await pickWebImageFile();
+        if (!asset?.uri) {
           return;
         }
+
+        applySelectedImage(asset);
+        return;
+      }
+
+      const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (status !== 'granted') {
+        Alert.alert('Permission needed', 'Gallery permission is required');
+        return;
       }
 
       const result = await ImagePicker.launchImageLibraryAsync({
         mediaTypes: ['images'],
-        allowsEditing: Platform.OS === 'web',
+        allowsEditing: false,
         aspect: [4, 3],
-        quality: Platform.OS === 'web' ? 0.82 : 0.65,
+        quality: 0.65,
       });
 
       if (result.canceled || !result.assets?.[0]?.uri) {
         return;
       }
 
-      navigation.setParams({
-        imageUri: result.assets[0].uri,
-        imageMimeType: result.assets[0].mimeType,
-        imageFileName: result.assets[0].fileName,
-        openCamera: false,
-        imgWcm: scaleHintCm,
-      });
+      applySelectedImage(result.assets[0]);
     } catch (err) {
       console.error('Gallery pick failed', err);
       Alert.alert('Error', 'Could not open gallery: ' + (err as Error)?.message);
@@ -862,13 +993,7 @@ export function ReviewMealScreen({ route, navigation }: any) {
             <Animated.View style={[styles.imageActionRow, statusAnimatedStyle]}>
               <Pressable
                 style={styles.imageActionBtn}
-                onPress={() => navigation.setParams({
-                  openCamera: true,
-                  imageUri: undefined,
-                  imageMimeType: undefined,
-                  imageFileName: undefined,
-                  imgWcm: scaleHintCm,
-                })}
+                onPress={handleRetake}
               >
                 <Camera size={18} color="#0F172A" />
                 <Text style={styles.imageActionBtnText}>Retake</Text>
@@ -1011,13 +1136,7 @@ export function ReviewMealScreen({ route, navigation }: any) {
               <View style={styles.emptyActionRow}>
                 <Pressable
                   style={[styles.inlineActionBtn, styles.inlineActionBtnPrimary]}
-                  onPress={() => navigation.setParams({
-                    openCamera: true,
-                    imageUri: undefined,
-                    imageMimeType: undefined,
-                    imageFileName: undefined,
-                    imgWcm: scaleHintCm,
-                  })}
+                  onPress={handleRetake}
                 >
                   <Text style={styles.inlineActionBtnPrimaryText}>Retake photo</Text>
                 </Pressable>


### PR DESCRIPTION
## Summary
- fix nutrition analyze error classification so transient provider failures map to service/time-out responses instead of misleading bad-request responses
- harden Gemini upload MIME normalization and filename fallback for image uploads
- fix `ReviewMealScreen` retake / choose-another flows so replacing a photo on web does not leave the screen blank

## Testing
- `./gradlew test --tests 'com.fitnessapp.backend.api.common.GlobalExceptionHandlerTest' --tests 'com.fitnessapp.backend.nutrition.service.ai.GeminiServiceTest'`
- `/Users/qingfengrumeng/dev/AuraFitness/node_modules/.bin/tsc --noEmit -p /tmp/aurafitness-pr/frontend/tsconfig.json`

## Notes
- I built this PR from a clean `HEAD` worktree to avoid including unrelated local edits already present in the main workspace.
- Live Gemini image verification is still blocked locally by an expired API key in the ignored dev config, which is separate from the code changes in this PR.