### PR TITLE
fix(camera): harden + correct the AR/depth real-world-scale module

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,15 @@
+/**
+ * Jest configuration for the Expo / React Native frontend.
+ *
+ * The `jest-expo` preset is required so that React Native + Expo packages (which
+ * ship untranspiled Flow/ESM) are transformed; without it every test that imports
+ * `react-native` fails with "Cannot use import statement outside a module".
+ */
+module.exports = {
+  preset: 'jest-expo',
+  setupFilesAfterEnv: [
+    '@testing-library/jest-native/extend-expect',
+    '<rootDir>/jest.setup.js',
+  ],
+  // jest-expo already transforms the RN/Expo module set; keep its defaults.
+};

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,0 +1,12 @@
+/**
+ * Global Jest setup for the frontend test suite.
+ *
+ * React Native native modules have no implementation under Jest, so the ones our
+ * code imports at module load must be mocked here.
+ */
+
+// AsyncStorage ships an official Jest mock; without it any module that imports it
+// throws "NativeModule: AsyncStorage is null" at require time.
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);

--- a/frontend/native-depth-plugin/README.md
+++ b/frontend/native-depth-plugin/README.md
@@ -1,26 +1,41 @@
-# `__getDepthAtCenter` — native depth frame-processor plugin
+# Native real-world-scale plugins (`__getDepthAtCenter` + `ARScaleModule`)
 
-This folder contains **reference templates** for the native VisionCamera frame-processor
-plugin that the JS layer already calls. The TypeScript side is fully wired:
+This folder contains **reference templates** for the native code that gives the meal
+camera a real-world scale (`img_w_cm`) so the backend can reason about portion size
+instead of guessing. There are two independent sources, by device tier:
+
+| Tier (`useDeviceCapabilities`) | Source | Native file | JS hook | Accuracy |
+|---|---|---|---|---|
+| `lidar` (LiDAR/ToF) | depth map center | `GetDepthAtCenterPlugin.swift` / `.kt` | `useDepthCamera` | ≈±1cm |
+| `standard_ar` (ARKit, no depth sensor) | horizontal-plane raycast | `ARScaleModule.swift` | `useARScale` | ≈±3cm |
+| `basic` | plate-reference default (35cm) | — | — | ≈±5cm |
+
+> ⚠️ These native files **cannot be compiled or tested outside Xcode / Android Studio
+> on a real device**. Treat them as correct starting points, not drop-in code.
+
+## What is actually wired today (read this before trusting the diagrams)
+
+- **`standard_ar` AR path — wired in JS, one device-side step remaining.**
+  `ARScaleModule.measure()` → `useARScale` (with a finiteness + 12–90cm plausibility
+  gate) → the capture screen passes `imgWcm` via `navigation.setParams(...)` →
+  `ReviewMealScreen` reads `route.params.imgWcm` (`ReviewMealScreen.tsx`) → sends
+  `img_w_cm` to the backend. The only missing piece is mounting the AR calibration
+  step on the capture screen (needs a real device — see below).
+- **`lidar`/`ToF` depth path — native template only; the JS conversion is NOT
+  implemented yet.** `useDepthCamera` exposes a `DepthResult` with `distanceCm`, but
+  **there is no `distance → img_w_cm` conversion in JS**, `DepthResult` does not carry
+  `fx`, and `CaptureMetadata` does not carry `imgWcm`. To finish this path you must add
+  the conversion and thread `imgWcm` into the same `route.params.imgWcm` the AR path
+  uses (see "Completing the LiDAR path"). Until then the depth plugin can run but its
+  scale never reaches the backend, and the app uses the 35cm plate default — safe, just
+  not yet adding LiDAR scale.
 
 ```
-LiDAR/ToF depth ──▶ global.__getDepthAtCenter(frame)   ← THIS PLUGIN (native)
-                    └▶ useDepthCamera (DepthResult)
-                       └▶ VisionCameraView capture metadata
-                          └▶ estimateImageWidthCm()  (src/utils/scale.ts)
-                             └▶ ReviewMealScreen → img_w_cm
-                                └▶ backend GeminiMealAnalysisService prompt scale
+standard_ar:  ARScaleModule.measure() → useARScale(imgWcm) → setParams → ReviewMealScreen → img_w_cm  ✅ wired (JS)
+lidar/ToF:    __getDepthAtCenter(frame) → useDepthCamera(DepthResult.distanceCm) → [ ⚠ no img_w_cm conversion yet ]
 ```
 
-Until this plugin is built into the app, `__getDepthAtCenter` is absent, the frame
-processor skips silently, `distanceCm` is `null`, `estimateImageWidthCm()` returns
-`null`, and the app falls back to the default plate-width assumption. So shipping
-without it is safe — it just doesn't add real scale yet.
-
-> ⚠️ These files cannot be compiled or tested outside Xcode / Android Studio on a
-> real LiDAR/ToF device. Treat them as a strong starting point, not drop-in code.
-
-## The contract (what the worklet must return)
+## The contract (what the depth plugin must return)
 
 A plain object matching `DepthResult` in `src/hooks/useDepthCamera.ts`:
 
@@ -30,99 +45,130 @@ A plain object matching `DepthResult` in `src/hooks/useDepthCamera.ts`:
   distance: number | null,      // meters, center of frame
   distanceCm: number | null,    // == distance * 100
   confidence: number,           // 0..1
-  width?: number,               // frame width in px (must match fx)
+  width?: number,
   height?: number,
-  fx?: number,                  // focal length in px (camera intrinsics) — preferred for scale
-  horizontalFovDeg?: number,    // fallback if fx is unavailable
-  accuracy?: 'absolute' | 'relative' | 'high' | 'medium' | 'low'
+  accuracy?: 'absolute' | 'relative' | 'high' | 'medium' | 'low',
+  error?: string,
 }
 ```
 
-`estimateImageWidthCm()` prefers `fx` + `width` (pinhole: `img_w_cm = distanceCm * width / fx`),
-and falls back to `horizontalFovDeg` (`img_w_cm = 2 · distanceCm · tan(HFOV/2)`). Returning
-`fx` is strongly preferred — it's the most accurate and avoids the FOV guess.
+The Swift/Kotlin templates also return an `fx` (focal length in px, scaled to the video
+frame width) — the value the pinhole conversion needs. **Note:** `fx` is **not** part of
+the `DepthResult` interface today, so it is currently ignored on the JS side. To use it,
+add `fx` (and `width`) to `DepthResult` and implement the conversion below.
+
+## Completing the LiDAR path (the missing JS conversion)
+
+The pinhole conversion the depth path needs (this helper does **not** exist in the repo
+yet — add it, e.g. `src/utils/scale.ts`):
+
+```ts
+// img_w_cm = distanceCm * frameWidthPx / fxPx   (fx and width in the SAME resolution)
+export function estimateImageWidthCm(distanceCm: number, fx: number, width: number): number | null {
+  if (!isFinite(distanceCm) || !(fx > 0) || !(width > 0)) return null;
+  const cm = (distanceCm * width) / fx;
+  return cm >= 12 && cm <= 90 ? cm : null; // same plausibility window as useARScale
+}
+```
+
+Then add `fx` to `DepthResult` + `CaptureMetadata`, compute `imgWcm` in
+`VisionCameraView.takePhoto`, and pass it through `route.params.imgWcm` exactly like the
+AR path. The native `fx` is "strongly preferred"; a `horizontalFovDeg`/FOV fallback is
+**not** implemented (the native side does not emit it).
 
 ## iOS (Swift) — `ios/GetDepthAtCenterPlugin.swift` + `.m`
 
-Two viable depth sources on iOS:
+A VisionCamera frame processor only receives the **video** `CMSampleBuffer`; iOS never
+attaches `AVDepthData` to it. So depth must come from a **separate**
+`AVCaptureDepthDataOutput`, paired with video via `AVCaptureDataOutputSynchronizer`. The
+template reflects this:
 
-1. **AVFoundation depth (this template).** Enable `AVCaptureDepthDataOutput` on the
-   capture session and synchronize it with video so the depth map is attached to the
-   frame. Read the center pixel of the `kCVPixelFormatType_DepthFloat32` map and
-   `cameraCalibrationData.intrinsicMatrix[0][0]` for `fx` (scale it to the video
-   frame width — see code).
-2. **ARKit (recommended for LiDAR).** Run an `ARSession` with
-   `configuration.frameSemantics = .sceneDepth`; read `frame.sceneDepth.depthMap`
-   center + `frame.camera.intrinsics[0][0]` for `fx`. Cleaner and dense on LiDAR
-   devices, but it's a separate camera session from VisionCamera — if you go this
-   route, expose depth via a small native module instead of a frame-processor
-   worklet and read it in `useDepthCamera` rather than through `__getDepthAtCenter`.
+1. Configure `AVCaptureDepthDataOutput` on your session and an
+   `AVCaptureDataOutputSynchronizer` over `[videoOutput, depthOutput]`. Enable
+   `isCameraCalibrationDataDeliveryEnabled` on the depth connection (otherwise `fx` is
+   unavailable and the plugin reports `hasDepth:false` rather than a bad scale).
+2. In the synchronizer delegate, push each synchronized depth into the store:
+   ```swift
+   let d = collection.synchronizedData(for: depthOutput) as? AVCaptureSynchronizedDepthData
+   if let d, !d.depthDataWasDropped { DepthStore.shared.update(d.depthData, timestamp: d.timestamp) }
+   ```
+   The frame processor reads the freshest depth that matches the current frame timestamp.
+3. **ARKit alternative for LiDAR.** Run an `ARSession` with
+   `frameSemantics = .sceneDepth` and read `frame.sceneDepth.depthMap` +
+   `frame.camera.intrinsics[0][0]`. That is a separate session from VisionCamera, so
+   expose it as a native module (like `ARScaleModule`) and read it in `useDepthCamera`.
 
-Register the plugin (VisionCamera v4) — see `.m` file. JS calls it as
-`global.__getDepthAtCenter(frame)` via the `useFrameProcessor` worklet already in
+Register the plugin (VisionCamera v4) — see the `.m` file. JS calls it as
+`global.__getDepthAtCenter(frame)` via the `useFrameProcessor` worklet in
 `useDepthCamera.ts`.
 
 ## Android (Kotlin) — `android/GetDepthAtCenterPlugin.kt`
 
-Use Camera2 `DEPTH16` / ToF output, read the center depth sample (millimeters →
-meters), and read `LENS_INTRINSIC_CALIBRATION` for `fx`. Register via
-`FrameProcessorPluginRegistry.addFrameProcessorPlugin("getDepthAtCenter", ...)`.
+Use a Camera2 `DEPTH16` / ToF output. VisionCamera delivers the YUV video frame, so depth
+comes from a parallel `ImageReader` keyed by timestamp — implement `DepthBridge`
+(`latestDepthImage` + `focalLengthPx`) to hand the latest depth `Image` and the
+`LENS_INTRINSIC_CALIBRATION` `fx` (scaled to frame width) to the plugin. The decode reads
+the low 13 bits as depth (mm) and the high 3 bits as the real confidence code. Register
+via `FrameProcessorPluginRegistry.addFrameProcessorPlugin("getDepthAtCenter", ...)`. If
+`fx` is 0 (DepthBridge not yet implemented) the plugin returns `hasDepth:false`.
 
 ## Build / test steps (on your machine)
 
-1. Copy the iOS files into your Xcode app target (and add the `-Swift.h` bridging
-   import in the `.m`); copy the Kotlin file into your Android app package.
-2. Ensure depth output is enabled on the capture session (iOS) / a DEPTH16 stream
-   is configured (Android).
-3. `cd frontend && npx expo prebuild` (or open `ios/`/`android/` directly), then
-   build to a **real device with LiDAR/ToF** (simulators have no depth).
-4. In the meal camera, confirm logs show a non-null `distanceCm` and that the
-   request to the backend now carries a measured `img_w_cm` (not the 35cm default).
+1. Copy the iOS files into your Xcode target (add the `-Swift.h` bridging import in the
+   `.m`); copy the Kotlin file into your Android package.
+2. Wire the depth source (iOS synchronizer → `DepthStore`; Android `DepthBridge`).
+3. `cd frontend && npx expo prebuild`, then build to a **real device with LiDAR/ToF**
+   (simulators have no depth).
+4. Implement the JS conversion above, then confirm the backend request carries a measured
+   `img_w_cm` (not the 35cm default).
 
-## How to verify the scale is actually flowing
+## How to verify scale is flowing
 
-- Add a temporary `console.log` of `metadata.imgWcm` in `VisionCameraView.takePhoto`.
+- AR path: log `imgWcm` returned by `useARScale.measure()`, and confirm
+  `route.params.imgWcm` is set on `ReviewMealScreen`.
+- Depth path (after wiring the conversion): log the computed `imgWcm` where you set
+  `route.params.imgWcm` — `CaptureMetadata` itself carries only
+  `{ distanceCm, confidence, accuracy, deviceTier }` today.
 - Backend `GeminiMealAnalysisService` logs the prompt context; confirm
-  `"img_w_cm": <measured>` appears instead of the default.
+  `"img_w_cm": <measured>` appears instead of the 35cm default.
 
 ---
 
-# `ARScaleModule` — standard_ar (no-LiDAR) scale source
+# `ARScaleModule` — `standard_ar` (no-LiDAR) scale source
 
-For the **`standard_ar` tier** (`useDeviceCapabilities`): devices with ARKit but **no** depth
-sensor (most non-Pro iPhones, ARCore Androids). Instead of a depth map, it raycasts the center of
-the frame to a detected **horizontal plane** (the table) and returns the camera-to-plane distance →
-`img_w_cm` via the same pinhole formula. This slots between LiDAR (±1cm) and the plate-reference
-fallback (±5cm), at ≈±3cm.
+For devices with ARKit but **no** depth sensor (most non-Pro iPhones, ARCore Androids).
+Instead of a depth map it raycasts the center of the frame to a detected **horizontal
+plane** (the table) and returns the camera-to-plane distance → `img_w_cm` via the same
+pinhole formula. Tier sits between LiDAR (±1cm) and the plate fallback (±5cm), at ≈±3cm.
 
 ```
-no depth sensor + ARKit ──▶ ARScaleModule.measure()  ← THIS MODULE (native)
-                            └▶ useARScale (imgWcm)
-                               └▶ ReviewMealScreen → img_w_cm  (same path as LiDAR)
+no depth sensor + ARKit ──▶ ARScaleModule.measure() ──▶ useARScale (imgWcm)
+                                                         └▶ ReviewMealScreen route param → img_w_cm  (same sink as the LiDAR path)
 ```
 
 Files: `ios/ARScaleModule.swift` + `ios/ARScaleModule.m`. JS: `src/hooks/useARScale.ts`
-(degrades to `supported=false` → plate fallback when the native module is absent — never fabricates
-a number). `measure()` returns `{ hasScale, distanceCm, imgWcm, fx, trackingState }`.
+(degrades to `supported=false` → plate fallback when the native module is absent — never
+fabricates a number). `measure()` returns `{ hasScale, distanceCm, imgWcm, fx, trackingState }`.
 
-> ⚠️ REFERENCE TEMPLATE — ARKit needs its own `ARSession`; it can't run at the same time as the
-> VisionCamera/expo-camera preview. Intended as a brief **calibration tap** (start → measure → stop)
-> on standard_ar devices, NOT a continuous parallel session.
+> ⚠️ REFERENCE TEMPLATE — ARKit needs its own `ARSession`; it can't run at the same time
+> as the VisionCamera/expo-camera preview. Intended as a brief **calibration tap**
+> (start → measure → stop), NOT a continuous parallel session.
 
 ## Integration (remaining device-side steps)
 
-1. Add `ARScaleModule.swift` + `.m` to the Xcode target (same `-Swift.h` bridging import as the
-   depth plugin). Ensure `NSCameraUsageDescription` is set.
-2. In the capture screen, for `tier === 'standard_ar'`, mount a small AR calibration step:
+1. Add `ARScaleModule.swift` + `.m` to the Xcode target (same `-Swift.h` bridging import
+   as the depth plugin). Ensure `NSCameraUsageDescription` is set.
+2. In the capture screen, for `tier === 'standard_ar'`, mount a brief AR calibration step:
    `const ar = useARScale(); await ar.start(); const imgWcm = await ar.measure(); ar.stop();`
-   then pass `imgWcm` into the same `navigation.setParams({ ... imgWcm })` path
-   `VisionCameraView` uses for LiDAR. (This is the part that needs a real device — ARKit raycasting
-   does not run in the simulator.)
-3. Android/ARCore equivalent (`ARCore` Frame `hitTest` on a detected plane) is a parallel TODO; the
+   then pass `imgWcm` into the same `navigation.setParams({ ... imgWcm })` sink
+   `ReviewMealScreen` reads. (This is the part that needs a real device — ARKit
+   raycasting does not run in the simulator.)
+3. Android/ARCore equivalent (`Frame.hitTest` on a detected plane) is a parallel TODO; the
    JS hook already no-ops on Android until added.
 
 ## Verify
 
 - `await NativeModules.ARScaleModule.isSupported()` → `true` on an ARKit device.
-- After a `measure()` with the camera aimed at food on a table, `imgWcm` is a plausible 12–90 cm
-  (clamped in `scale.ts`), and the backend prompt carries `"img_w_cm": <measured>`.
+- After a `measure()` aimed at food on a table, `useARScale` returns a value inside the
+  plausible **12–90 cm** window (out-of-range raycasts are gated to `null` in
+  `useARScale`, **not** clamped), and the backend prompt carries `"img_w_cm": <measured>`.

--- a/frontend/native-depth-plugin/README.md
+++ b/frontend/native-depth-plugin/README.md
@@ -15,24 +15,30 @@ instead of guessing. There are two independent sources, by device tier:
 
 ## What is actually wired today (read this before trusting the diagrams)
 
-- **`standard_ar` AR path — wired in JS, one device-side step remaining.**
-  `ARScaleModule.measure()` → `useARScale` (with a finiteness + 12–90cm plausibility
-  gate) → the capture screen passes `imgWcm` via `navigation.setParams(...)` →
-  `ReviewMealScreen` reads `route.params.imgWcm` (`ReviewMealScreen.tsx`) → sends
-  `img_w_cm` to the backend. The only missing piece is mounting the AR calibration
-  step on the capture screen (needs a real device — see below).
-- **`lidar`/`ToF` depth path — native template only; the JS conversion is NOT
-  implemented yet.** `useDepthCamera` exposes a `DepthResult` with `distanceCm`, but
-  **there is no `distance → img_w_cm` conversion in JS**, `DepthResult` does not carry
-  `fx`, and `CaptureMetadata` does not carry `imgWcm`. To finish this path you must add
-  the conversion and thread `imgWcm` into the same `route.params.imgWcm` the AR path
-  uses (see "Completing the LiDAR path"). Until then the depth plugin can run but its
-  scale never reaches the backend, and the app uses the 35cm plate default — safe, just
-  not yet adding LiDAR scale.
+Only the **sink** is wired end-to-end: `ReviewMealScreen` reads `route.params.imgWcm`
+(`ReviewMealScreen.tsx`) and sends it to the backend as `img_w_cm`, defaulting to the
+35cm plate width when absent. Everything that would *produce* a measured `imgWcm` is
+still a template / unwired:
+
+- **`standard_ar` AR path — native template + JS hook exist; NOT yet called.**
+  `ARScaleModule.swift` (template) and `useARScale` (with a finiteness + 12–90cm
+  plausibility gate) are in place, but **nothing in the app calls `useARScale` or sets
+  `route.params.imgWcm`** — `grep` finds no caller. Remaining work: (a) build the native
+  module into the app (real device), AND (b) write the JS glue on the capture screen
+  (`useARScale().measure()` → `navigation.setParams({ imgWcm })`).
+- **`lidar`/`ToF` depth path — native template only; no JS conversion at all.**
+  `useDepthCamera` exposes a `DepthResult` with `distanceCm`, but **there is no
+  `distance → img_w_cm` conversion in JS**, `DepthResult` does not carry `fx`, and
+  `CaptureMetadata` does not carry `imgWcm`. Remaining work: build the native plugin,
+  add the conversion (see "Completing the LiDAR path"), and thread `imgWcm` into the same
+  `route.params.imgWcm` sink.
+
+So today every meal uses the 35cm plate default — safe, just not yet adding real scale.
 
 ```
-standard_ar:  ARScaleModule.measure() → useARScale(imgWcm) → setParams → ReviewMealScreen → img_w_cm  ✅ wired (JS)
-lidar/ToF:    __getDepthAtCenter(frame) → useDepthCamera(DepthResult.distanceCm) → [ ⚠ no img_w_cm conversion yet ]
+sink (wired):  route.params.imgWcm → ReviewMealScreen → img_w_cm  (defaults to 35cm)
+standard_ar:   ARScaleModule.measure() → useARScale(imgWcm) → [ ⚠ no caller; setParams glue unwritten ] ┐
+lidar/ToF:     __getDepthAtCenter(frame) → useDepthCamera(distanceCm) → [ ⚠ no img_w_cm conversion ]    ┴▶ route.params.imgWcm
 ```
 
 ## The contract (what the depth plugin must return)
@@ -129,8 +135,11 @@ via `FrameProcessorPluginRegistry.addFrameProcessorPlugin("getDepthAtCenter", ..
 - Depth path (after wiring the conversion): log the computed `imgWcm` where you set
   `route.params.imgWcm` — `CaptureMetadata` itself carries only
   `{ distanceCm, confidence, accuracy, deviceTier }` today.
-- Backend `GeminiMealAnalysisService` logs the prompt context; confirm
-  `"img_w_cm": <measured>` appears instead of the 35cm default.
+- Confirm the value reaches the backend: inspect the outbound nutrition request
+  (`nutritionApi.ts` sends `img_w_cm`) and check it carries the measured value, not the
+  35cm default. (The backend reads `img_w_cm` for portion/scale reasoning, but
+  `GeminiMealAnalysisService` does not log the request body, so verify it client-side or
+  via your API gateway logs.)
 
 ---
 

--- a/frontend/native-depth-plugin/android/GetDepthAtCenterPlugin.kt
+++ b/frontend/native-depth-plugin/android/GetDepthAtCenterPlugin.kt
@@ -32,28 +32,42 @@ class GetDepthAtCenterPlugin(
       return hashMapOf("hasDepth" to false, "width" to width, "height" to height)
     }
 
-    val meters = readCenterDepthMeters(depthImage)
-    if (meters == null || meters <= 0f) {
+    val sample = readCenterDepth(depthImage)
+    if (sample == null || sample.meters <= 0f) {
       return hashMapOf("hasDepth" to false, "width" to width, "height" to height)
     }
 
     // fx (px) from LENS_INTRINSIC_CALIBRATION [fx, fy, cx, cy, s], scaled to frame width.
     val fx = DepthBridge.focalLengthPx(width)
+    // Without intrinsics we cannot convert distance -> img_w_cm; report no usable depth
+    // rather than emitting fx:0 (which divides to Infinity/NaN downstream).
+    if (fx <= 0f) {
+      return hashMapOf("hasDepth" to false, "width" to width, "height" to height)
+    }
 
     return hashMapOf(
       "hasDepth" to true,
-      "distance" to meters,
-      "distanceCm" to meters * 100.0,
-      "confidence" to 0.9,
+      "distance" to sample.meters,
+      "distanceCm" to sample.meters * 100.0,
+      "confidence" to sample.confidence, // real DEPTH16 confidence, not a hardcoded value
       "fx" to fx,
       "width" to width,
       "height" to height,
-      "accuracy" to "absolute"
+      // High measured confidence => treat as a calibrated/absolute reading.
+      "accuracy" to if (sample.confidence >= 0.66f) "absolute" else "relative"
     )
   }
 
-  /** DEPTH16: each sample is 16-bit; low 13 bits = depth in millimeters, high 3 bits = confidence. */
-  private fun readCenterDepthMeters(image: Image): Float? {
+  private data class DepthSample(val meters: Float, val confidence: Float)
+
+  /**
+   * DEPTH16: each 16-bit sample packs depth in the low 13 bits (millimeters) and a
+   * confidence code in the high 3 bits. Per the Android format spec the code maps to a
+   * percentage as: 0 => 100% confident, otherwise (code - 1) / 7. We return the median
+   * depth and the mean confidence over the valid samples in the centre window — so the
+   * JS-side minConfidence filter is actually meaningful instead of a no-op 0.9.
+   */
+  private fun readCenterDepth(image: Image): DepthSample? {
     val plane = image.planes.firstOrNull() ?: return null
     val buffer = plane.buffer
     val rowStride = plane.rowStride
@@ -66,24 +80,29 @@ class GetDepthAtCenterPlugin(
     val cy = h / 2
     val radius = maxOf(1, minOf(w, h) / 64)
 
-    val samples = ArrayList<Float>()
+    val depths = ArrayList<Float>()
+    var confidenceSum = 0f
     var y = maxOf(0, cy - radius)
     while (y <= minOf(h - 1, cy + radius)) {
       var x = maxOf(0, cx - radius)
       while (x <= minOf(w - 1, cx + radius)) {
         val index = y * rowStride + x * pixelStride
         if (index + 1 < buffer.limit()) {
-          val sample = (buffer.get(index).toInt() and 0xFF) or ((buffer.get(index + 1).toInt() and 0xFF) shl 8)
-          val millimeters = sample and 0x1FFF // low 13 bits
-          if (millimeters > 0) samples.add(millimeters / 1000f)
+          val raw = (buffer.get(index).toInt() and 0xFF) or ((buffer.get(index + 1).toInt() and 0xFF) shl 8)
+          val millimeters = raw and 0x1FFF       // low 13 bits
+          val code = (raw shr 13) and 0x7         // high 3 bits = confidence code
+          if (millimeters > 0) {
+            depths.add(millimeters / 1000f)
+            confidenceSum += if (code == 0) 1f else (code - 1) / 7f
+          }
         }
         x++
       }
       y++
     }
-    if (samples.isEmpty()) return null
-    samples.sort()
-    return samples[samples.size / 2] // median, meters
+    if (depths.isEmpty()) return null
+    depths.sort()
+    return DepthSample(depths[depths.size / 2], confidenceSum / depths.size)
   }
 }
 

--- a/frontend/native-depth-plugin/ios/GetDepthAtCenterPlugin.swift
+++ b/frontend/native-depth-plugin/ios/GetDepthAtCenterPlugin.swift
@@ -4,8 +4,15 @@
 //  intrinsics so the JS layer can compute a real-world image width (img_w_cm).
 //
 //  ⚠️ REFERENCE TEMPLATE — must be built & tested in Xcode on a real LiDAR/ToF device.
-//  Depth is only attached to the frame if your capture session has depth output
-//  enabled and synchronized with the video output (see README).
+//
+//  IMPORTANT ARCHITECTURE NOTE:
+//  A VisionCamera frame processor only receives the VIDEO CMSampleBuffer; on iOS,
+//  AVDepthData is NEVER attached to that video buffer. Depth is delivered separately
+//  by AVCaptureDepthDataOutput, paired with video through AVCaptureDataOutputSynchronizer.
+//  So this plugin does NOT try to read depth off the frame buffer. Instead your capture
+//  session's synchronizer delegate pushes each AVDepthData into `DepthStore.shared`
+//  (keyed by presentation timestamp), and the plugin reads the freshest depth that
+//  matches the current frame — the iOS analogue of the Android `DepthBridge`.
 //
 //  VisionCamera v4 plugin API.
 //
@@ -15,6 +22,41 @@ import VisionCamera
 import AVFoundation
 import CoreVideo
 import CoreMedia
+
+/// Thread-safe hand-off between the app's AVCaptureDataOutputSynchronizer delegate and
+/// the frame processor. Populate it from `dataOutputSynchronizer(_:didOutput:)` when a
+/// synchronized AVDepthData arrives:
+///
+///     let depth = collection.synchronizedData(for: depthOutput) as? AVCaptureSynchronizedDepthData
+///     if let d = depth, !d.depthDataWasDropped {
+///       DepthStore.shared.update(d.depthData, timestamp: d.timestamp)
+///     }
+@objc(DepthStore)
+public final class DepthStore: NSObject {
+  @objc public static let shared = DepthStore()
+
+  private let lock = NSLock()
+  private var latest: AVDepthData?
+  private var latestTimeSeconds: Double = -1
+  /// Max age between the video frame and the stored depth before we treat it as stale.
+  private let maxPairingAgeSeconds = 0.12
+
+  @objc public func update(_ depthData: AVDepthData, timestamp: CMTime) {
+    lock.lock(); defer { lock.unlock() }
+    latest = depthData
+    latestTimeSeconds = timestamp.seconds
+  }
+
+  /// Latest depth that is fresh enough to pair with a frame at `frameTimeSeconds`.
+  fileprivate func depthData(near frameTimeSeconds: Double) -> AVDepthData? {
+    lock.lock(); defer { lock.unlock() }
+    guard let d = latest, latestTimeSeconds >= 0 else { return nil }
+    if frameTimeSeconds >= 0, abs(frameTimeSeconds - latestTimeSeconds) > maxPairingAgeSeconds {
+      return nil // never pair a stale depth map with a newer video frame
+    }
+    return d
+  }
+}
 
 @objc(GetDepthAtCenterPlugin)
 public class GetDepthAtCenterPlugin: FrameProcessorPlugin {
@@ -34,14 +76,12 @@ public class GetDepthAtCenterPlugin: FrameProcessorPlugin {
       frameHeight = CVPixelBufferGetHeight(imageBuffer)
     }
 
-    // Obtain the AVDepthData attached to this frame.
-    // Requires AVCaptureDepthDataOutput synchronized with video on the session.
-    guard let depthData = Self.depthData(from: sampleBuffer) else {
-      return [
-        "hasDepth": false,
-        "width": frameWidth,
-        "height": frameHeight,
-      ]
+    let noDepth: [String: Any] = ["hasDepth": false, "width": frameWidth, "height": frameHeight]
+
+    // Pull the synchronized depth pushed by the session's synchronizer delegate.
+    let frameTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer).seconds
+    guard let depthData = DepthStore.shared.depthData(near: frameTime) else {
+      return noDepth
     }
 
     // Normalize to Float32 depth (meters).
@@ -56,7 +96,7 @@ public class GetDepthAtCenterPlugin: FrameProcessorPlugin {
     let dw = CVPixelBufferGetWidth(depthMap)
     let dh = CVPixelBufferGetHeight(depthMap)
     guard dw > 0, dh > 0, let base = CVPixelBufferGetBaseAddress(depthMap) else {
-      return ["hasDepth": false, "width": frameWidth, "height": frameHeight]
+      return noDepth
     }
 
     // Sample a small window at the center and take the median to reduce noise.
@@ -77,13 +117,13 @@ public class GetDepthAtCenterPlugin: FrameProcessorPlugin {
       y += 1
     }
 
-    guard !samples.isEmpty else {
-      return ["hasDepth": false, "width": frameWidth, "height": frameHeight]
-    }
+    guard !samples.isEmpty else { return noDepth }
     samples.sort()
     let meters = samples[samples.count / 2] // median, in meters
 
     // Camera intrinsics → fx in pixels, scaled to the video frame width.
+    // intrinsicMatrix is expressed relative to intrinsicMatrixReferenceDimensions, so
+    // it must be rescaled to the actual video frame width before use.
     var fx: Float = 0
     if let cal = converted.cameraCalibrationData {
       let refDims = cal.intrinsicMatrixReferenceDimensions
@@ -94,6 +134,12 @@ public class GetDepthAtCenterPlugin: FrameProcessorPlugin {
         fx = fxRef
       }
     }
+
+    // Without intrinsics (cameraCalibrationData is often nil unless
+    // isCameraCalibrationDataDeliveryEnabled is set on the depth output) we cannot
+    // convert distance → img_w_cm. Report "no usable depth" rather than emitting fx:0,
+    // which would divide to Infinity/NaN in the JS pinhole formula.
+    guard fx > 0 else { return noDepth }
 
     // Confidence from accuracy flag (absolute = calibrated LiDAR).
     let confidence: Float = converted.depthDataAccuracy == .absolute ? 0.95 : 0.7
@@ -108,19 +154,5 @@ public class GetDepthAtCenterPlugin: FrameProcessorPlugin {
       "height": frameHeight,
       "accuracy": converted.depthDataAccuracy == .absolute ? "absolute" : "relative",
     ] as [String: Any]
-  }
-
-  /// Read AVDepthData attached to the sample buffer (requires depth output enabled & synced).
-  private static func depthData(from sampleBuffer: CMSampleBuffer) -> AVDepthData? {
-    guard let attachment = CMGetAttachment(
-      sampleBuffer,
-      key: "AVDepthData" as CFString, // see README: set via your synchronized depth output
-      attachmentModeOut: nil
-    ) else {
-      return nil
-    }
-    // When using AVCaptureDataOutputSynchronizer you typically have the AVDepthData
-    // object directly — pass it through to this plugin instead of via attachment.
-    return attachment as? AVDepthData
   }
 }

--- a/frontend/native-depth-plugin/ios/GetDepthAtCenterPlugin.swift
+++ b/frontend/native-depth-plugin/ios/GetDepthAtCenterPlugin.swift
@@ -10,9 +10,10 @@
 //  AVDepthData is NEVER attached to that video buffer. Depth is delivered separately
 //  by AVCaptureDepthDataOutput, paired with video through AVCaptureDataOutputSynchronizer.
 //  So this plugin does NOT try to read depth off the frame buffer. Instead your capture
-//  session's synchronizer delegate pushes each AVDepthData into `DepthStore.shared`
-//  (keyed by presentation timestamp), and the plugin reads the freshest depth that
-//  matches the current frame — the iOS analogue of the Android `DepthBridge`.
+//  session's synchronizer delegate pushes the latest AVDepthData (plus its presentation
+//  timestamp) into `DepthStore.shared`, and the plugin reads it back only if it is fresh
+//  enough to pair with the current frame — the iOS analogue of the Android `DepthBridge`.
+//  (DepthStore keeps just the most recent sample, not a timestamp-indexed history.)
 //
 //  VisionCamera v4 plugin API.
 //

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,7 @@
     "jest": "^29.7.0",
     "jest-expo": "~54.0.16",
     "react-refresh": "^0.18.0",
-    "react-test-renderer": "^19.2.3",
+    "react-test-renderer": "19.1.0",
     "typescript": "~5.9.2"
   },
   "private": true

--- a/frontend/src/hooks/__tests__/distanceEstimation.contract.test.tsx
+++ b/frontend/src/hooks/__tests__/distanceEstimation.contract.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Contract tests for useDistanceEstimation + the device-tier wiring it reads from
+ * useDeviceCapabilities.
+ *
+ * Central guarantee (per the hook's own docstring and the README): the expo-camera
+ * fallback path CANNOT read a depth sensor, so this hook must NEVER fabricate a
+ * distance — `distance` stays null unless the user sets one manually. Tier only
+ * affects the accuracy LABEL.
+ */
+// iPhone 11 — ARKit but NO LiDAR => standard_ar tier. Defined as getters so this
+// fully replaces jest-expo's built-in (empty-string) expo-device stub.
+jest.mock('expo-device', () => ({
+  __esModule: true,
+  get modelId() { return 'iPhone12,1'; },
+  get modelName() { return 'iPhone 11'; },
+  get osVersion() { return '17.0'; },
+  get brand() { return 'Apple'; },
+}));
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import * as Device from 'expo-device';
+import { useDistanceEstimation } from '../useDistanceEstimation';
+
+describe('useDistanceEstimation — never fabricates distance', () => {
+  it('after auto-start, distance stays null (no simulated depth); status becomes ready', async () => {
+    const { result } = renderHook(() => useDistanceEstimation());
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(result.current.distance).toBeNull();
+    expect(result.current.confidence).toBeGreaterThan(0);
+  });
+
+  it('reflects the standard_ar tier label (±3cm) for an ARKit/no-LiDAR device', async () => {
+    const { result } = renderHook(() => useDistanceEstimation());
+    await waitFor(() => expect(result.current.deviceTier).toBe('standard_ar'));
+    expect(result.current.accuracy).toBe('±3cm');
+  });
+
+  it('setManualDistance enforces min/max and fires onReady inside the band', async () => {
+    const onReady = jest.fn();
+    const { result } = renderHook(() =>
+      useDistanceEstimation({ minDistance: 20, maxDistance: 60, onReady })
+    );
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    act(() => result.current.setManualDistance(10));
+    expect(result.current.status).toBe('too_close');
+
+    act(() => result.current.setManualDistance(100));
+    expect(result.current.status).toBe('too_far');
+
+    act(() => result.current.setManualDistance(35));
+    expect(result.current.status).toBe('ready');
+    expect(result.current.distance).toBe(35);
+    expect(onReady).toHaveBeenCalledWith(35);
+  });
+});

--- a/frontend/src/hooks/__tests__/useARScale.absent.test.ts
+++ b/frontend/src/hooks/__tests__/useARScale.absent.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Contract tests for useARScale WHEN the native ARScaleModule is absent —
+ * i.e. web, Expo Go, a build where the reference template hasn't been added to the
+ * Xcode target yet, or Android (no ARCore equivalent wired). This is the default
+ * shipping state today. The README's promise: it degrades to the plate-reference
+ * fallback and NEVER fabricates a scale.
+ */
+import { NativeModules, Platform } from 'react-native';
+import { renderHook, act } from '@testing-library/react-native';
+
+(Platform as any).OS = 'ios';
+delete (NativeModules as any).ARScaleModule; // not built into the target
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { useARScale } = require('../useARScale');
+
+describe('useARScale (native ARScaleModule ABSENT)', () => {
+  it('reports supported=false', async () => {
+    const { result } = renderHook(() => useARScale());
+    await act(async () => { await Promise.resolve(); });
+    expect(result.current.supported).toBe(false);
+  });
+
+  it('measure() resolves to null (caller falls back to plate scale) and never throws', async () => {
+    const { result } = renderHook(() => useARScale());
+    let v: number | null = -1;
+    await act(async () => { v = await result.current.measure(); });
+    expect(v).toBeNull();
+    expect(result.current.imgWcm).toBeNull();
+  });
+
+  it('start() / stop() are safe no-ops', async () => {
+    const { result } = renderHook(() => useARScale());
+    await act(async () => {
+      await result.current.start();
+      await result.current.stop();
+    });
+    expect(result.current.imgWcm).toBeNull();
+  });
+});

--- a/frontend/src/hooks/__tests__/useARScale.native.test.ts
+++ b/frontend/src/hooks/__tests__/useARScale.native.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Contract tests for useARScale WHEN the native ARScaleModule is present.
+ *
+ * These exercise the JS bridge that the native ARKit reference template
+ * (native-depth-plugin/ios/ARScaleModule.swift) talks to. They cannot exercise
+ * ARKit itself (needs a real device) — they pin the SAFETY CONTRACT the README
+ * promises: a scale number only ever propagates when the native side reports a
+ * finite, real measurement. Anything else degrades to null (plate fallback).
+ *
+ * NOTE: the hook captures `NativeModules.ARScaleModule` at module-eval time, so we
+ * install the mock BEFORE require()-ing the hook (jest isolates module state per file).
+ */
+import { NativeModules, Platform } from 'react-native';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import type { UseARScale } from '../useARScale';
+
+(Platform as any).OS = 'ios';
+const measure = jest.fn();
+const start = jest.fn().mockResolvedValue(true);
+const stop = jest.fn().mockResolvedValue(true);
+const isSupported = jest.fn().mockResolvedValue(true);
+(NativeModules as any).ARScaleModule = { isSupported, start, stop, measure };
+
+// Typed require (after the mock is installed) so renderHook keeps its generics.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { useARScale } = require('../useARScale') as typeof import('../useARScale');
+
+describe('useARScale (native ARScaleModule present)', () => {
+  beforeEach(() => {
+    measure.mockReset();
+    start.mockClear().mockResolvedValue(true);
+    stop.mockClear().mockResolvedValue(true);
+    isSupported.mockClear().mockResolvedValue(true);
+  });
+
+  it('propagates a finite imgWcm when the plane raycast succeeds', async () => {
+    measure.mockResolvedValue({ hasScale: true, imgWcm: 32.5, distanceCm: 28, fx: 1500 });
+    const { result } = renderHook(() => useARScale());
+    let v: number | null = -1;
+    await act(async () => { v = await result.current.measure(); });
+    expect(v).toBe(32.5);
+    expect(result.current.imgWcm).toBe(32.5);
+  });
+
+  it('NEVER fabricates: hasScale=false -> null', async () => {
+    measure.mockResolvedValue({ hasScale: false });
+    const { result } = renderHook(() => useARScale());
+    let v: number | null = -1;
+    await act(async () => { v = await result.current.measure(); });
+    expect(v).toBeNull();
+    expect(result.current.imgWcm).toBeNull();
+  });
+
+  it('NEVER fabricates: non-finite imgWcm (NaN / Infinity) -> null', async () => {
+    const { result } = renderHook(() => useARScale());
+    let nanV: number | null = -1;
+    let infV: number | null = -1;
+    measure.mockResolvedValueOnce({ hasScale: true, imgWcm: NaN });
+    await act(async () => { nanV = await result.current.measure(); });
+    measure.mockResolvedValueOnce({ hasScale: true, imgWcm: Infinity });
+    await act(async () => { infV = await result.current.measure(); });
+    expect(nanV).toBeNull();
+    expect(infV).toBeNull();
+  });
+
+  it('NEVER fabricates: null/missing imgWcm -> null', async () => {
+    measure.mockResolvedValue({ hasScale: true, imgWcm: null });
+    const { result } = renderHook(() => useARScale());
+    let v: number | null = -1;
+    await act(async () => { v = await result.current.measure(); });
+    expect(v).toBeNull();
+  });
+
+  it('plausibility gate: out-of-range imgWcm (far-wall / too-close raycast) -> null', async () => {
+    const { result } = renderHook(() => useARScale());
+    let tooFar: number | null = -1;
+    let tooClose: number | null = -1;
+    measure.mockResolvedValueOnce({ hasScale: true, imgWcm: 220 });
+    await act(async () => { tooFar = await result.current.measure(); });
+    measure.mockResolvedValueOnce({ hasScale: true, imgWcm: 4 });
+    await act(async () => { tooClose = await result.current.measure(); });
+    expect(tooFar).toBeNull();
+    expect(tooClose).toBeNull();
+  });
+
+  it('plausibility gate: accepts the documented 12-90 cm boundaries', async () => {
+    const { result } = renderHook(() => useARScale());
+    let lo: number | null = -1;
+    let hi: number | null = -1;
+    measure.mockResolvedValueOnce({ hasScale: true, imgWcm: 12 });
+    await act(async () => { lo = await result.current.measure(); });
+    measure.mockResolvedValueOnce({ hasScale: true, imgWcm: 90 });
+    await act(async () => { hi = await result.current.measure(); });
+    expect(lo).toBe(12);
+    expect(hi).toBe(90);
+  });
+
+  it('restarts cleanly after an enabled toggle (cleanup resets the start guard)', async () => {
+    const { result, rerender } = renderHook<UseARScale, { enabled: boolean }>(
+      ({ enabled }) => useARScale(enabled),
+      { initialProps: { enabled: true } }
+    );
+    await act(async () => { await result.current.start(); });
+    expect(start).toHaveBeenCalledTimes(1);
+    // Disable -> effect cleanup must stop the session AND reset the guard.
+    await act(async () => { rerender({ enabled: false }); });
+    expect(stop).toHaveBeenCalled();
+    // Re-enable and start again -> must actually restart (was broken before the fix).
+    await act(async () => { rerender({ enabled: true }); });
+    await act(async () => { await result.current.start(); });
+    expect(start).toHaveBeenCalledTimes(2);
+  });
+
+  it('swallows a native measure() rejection -> null (no throw to caller)', async () => {
+    measure.mockRejectedValue(new Error('AR session interrupted'));
+    const { result } = renderHook(() => useARScale());
+    let v: number | null = -1;
+    await act(async () => { v = await result.current.measure(); });
+    expect(v).toBeNull();
+  });
+
+  it('reports supported=true when the device reports ARWorldTracking support', async () => {
+    const { result } = renderHook(() => useARScale());
+    await waitFor(() => expect(result.current.supported).toBe(true));
+  });
+
+  it('start() is idempotent and stop() releases the session', async () => {
+    const { result } = renderHook(() => useARScale());
+    await act(async () => { await result.current.start(); });
+    await act(async () => { await result.current.start(); });
+    expect(start).toHaveBeenCalledTimes(1); // guarded by started ref
+    await act(async () => { await result.current.stop(); });
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/__tests__/useDeviceCapabilities.test.tsx
+++ b/frontend/src/hooks/__tests__/useDeviceCapabilities.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Regression tests for device-tier classification.
+ *
+ * Guards the fixes that removed non-LiDAR iPhones from the LiDAR list, switched to
+ * exact model-id matching, added the iPad Pro 12.9" 5th-gen ids, and relabeled the
+ * depth tier so Android ToF devices aren't called "LiDAR".
+ */
+import { Platform } from 'react-native';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+// Mutable expo-device stand-in (getters fully replace jest-expo's empty stub).
+const mockState = { modelId: '', modelName: '', osVersion: '17.0', brand: 'Apple' };
+jest.mock('expo-device', () => ({
+  __esModule: true,
+  get modelId() { return mockState.modelId; },
+  get modelName() { return mockState.modelName; },
+  get osVersion() { return mockState.osVersion; },
+  get brand() { return mockState.brand; },
+}));
+
+import { useDeviceCapabilities, getTierDescription } from '../useDeviceCapabilities';
+
+describe('useDeviceCapabilities tiering', () => {
+  beforeEach(() => {
+    (Platform as any).OS = 'ios';
+    mockState.modelId = '';
+    mockState.modelName = '';
+    mockState.osVersion = '17.0';
+    mockState.brand = 'Apple';
+  });
+
+  it('iPhone 15 Pro Max (iPhone15,3) -> lidar tier', async () => {
+    mockState.modelId = 'iPhone15,3';
+    const { result } = renderHook(() => useDeviceCapabilities());
+    await waitFor(() => expect(result.current.tier).toBe('lidar'));
+    expect(result.current.hasLiDAR).toBe(true);
+    expect(result.current.estimatedAccuracy).toBe('< 1%');
+  });
+
+  it('iPhone 13 (iPhone14,5) -> standard_ar, NOT lidar (it has no LiDAR)', async () => {
+    mockState.modelId = 'iPhone14,5';
+    const { result } = renderHook(() => useDeviceCapabilities());
+    await waitFor(() => expect(result.current.tier).toBe('standard_ar'));
+    expect(result.current.hasLiDAR).toBe(false);
+  });
+
+  it('iPad Pro 12.9" 5th gen (iPad13,8) -> lidar tier', async () => {
+    mockState.modelId = 'iPad13,8';
+    const { result } = renderHook(() => useDeviceCapabilities());
+    await waitFor(() => expect(result.current.tier).toBe('lidar'));
+    expect(result.current.hasLiDAR).toBe(true);
+  });
+
+  it('Galaxy S23 Ultra (SM-S918, ToF) -> high tier but NOT labeled LiDAR', async () => {
+    (Platform as any).OS = 'android';
+    mockState.modelId = 'SM-S918B';
+    mockState.modelName = 'Galaxy S23 Ultra';
+    mockState.osVersion = '14';
+    mockState.brand = 'samsung';
+    const { result } = renderHook(() => useDeviceCapabilities());
+    await waitFor(() => expect(result.current.hasToF).toBe(true));
+    expect(result.current.tier).toBe('lidar'); // shared high-accuracy depth tier
+    expect(getTierDescription(result.current.tier)).toBe('Pro Accuracy (Depth Sensor)');
+  });
+
+  it('getTierDescription no longer claims LiDAR for the depth tier', () => {
+    expect(getTierDescription('lidar')).toBe('Pro Accuracy (Depth Sensor)');
+    expect(getTierDescription('standard_ar')).toBe('Standard Accuracy (AR)');
+    expect(getTierDescription('basic')).toBe('Basic Mode');
+  });
+});

--- a/frontend/src/hooks/useARScale.ts
+++ b/frontend/src/hooks/useARScale.ts
@@ -31,6 +31,14 @@ interface ARScaleNative {
 const Native: ARScaleNative | undefined =
   Platform.OS === 'ios' ? (NativeModules.ARScaleModule as ARScaleNative | undefined) : undefined;
 
+// Plausible real-world image-width window for a food close-up. A plane raycast that
+// lands on something other than the table (e.g. a far wall) produces a wildly
+// out-of-range width; rather than feed the backend a fabricated scale we drop it and
+// let the caller fall back to the plate-reference default. (±cm bounds documented in
+// native-depth-plugin/README.md.)
+const MIN_PLAUSIBLE_IMG_W_CM = 12;
+const MAX_PLAUSIBLE_IMG_W_CM = 90;
+
 export interface UseARScale {
   /** Native module present AND device reports ARWorldTracking support. */
   supported: boolean;
@@ -56,7 +64,10 @@ export function useARScale(enabled = true): UseARScale {
     }
     return () => {
       alive = false;
-      if (started.current) Native?.stop().catch(() => {});
+      if (started.current) {
+        Native?.stop().catch(() => {});
+        started.current = false; // keep the start-guard in sync so a later start() can restart
+      }
     };
   }, [enabled]);
 
@@ -74,7 +85,14 @@ export function useARScale(enabled = true): UseARScale {
     if (!Native) return null;
     try {
       const m = await Native.measure();
-      const v = m.hasScale && typeof m.imgWcm === 'number' && isFinite(m.imgWcm) ? m.imgWcm : null;
+      const finite =
+        m.hasScale && typeof m.imgWcm === 'number' && isFinite(m.imgWcm) ? m.imgWcm : null;
+      // Plausibility gate: only a value inside the food-framing window is trusted;
+      // anything else degrades to the plate fallback rather than fabricating a scale.
+      const v =
+        finite !== null && finite >= MIN_PLAUSIBLE_IMG_W_CM && finite <= MAX_PLAUSIBLE_IMG_W_CM
+          ? finite
+          : null;
       if (v !== null) setImgWcm(v);
       return v;
     } catch {

--- a/frontend/src/hooks/useDeviceCapabilities.ts
+++ b/frontend/src/hooks/useDeviceCapabilities.ts
@@ -35,9 +35,10 @@ const LIDAR_IPHONE_MODELS = [
 
 // iPad Pro models with LiDAR (2020+)
 const LIDAR_IPAD_MODELS = [
-  'iPad8,9', 'iPad8,10', 'iPad8,11', 'iPad8,12', // iPad Pro 2020
-  'iPad13,4', 'iPad13,5', 'iPad13,6', 'iPad13,7', // iPad Pro 2021
-  'iPad14,3', 'iPad14,4', 'iPad14,5', 'iPad14,6', // iPad Pro 2022
+  'iPad8,9', 'iPad8,10', 'iPad8,11', 'iPad8,12', // iPad Pro 2020 (11" 2nd gen / 12.9" 4th gen)
+  'iPad13,4', 'iPad13,5', 'iPad13,6', 'iPad13,7', // iPad Pro 2021 11" 3rd gen
+  'iPad13,8', 'iPad13,9', 'iPad13,10', 'iPad13,11', // iPad Pro 2021 12.9" 5th gen (M1)
+  'iPad14,3', 'iPad14,4', 'iPad14,5', 'iPad14,6', // iPad Pro 2022 (11" 4th gen / 12.9" 6th gen)
 ];
 
 // Android models known to have ToF sensors

--- a/frontend/src/hooks/useDeviceCapabilities.ts
+++ b/frontend/src/hooks/useDeviceCapabilities.ts
@@ -23,14 +23,14 @@ export interface DeviceCapabilities {
   estimatedAccuracy: string; // e.g., "< 1%", "< 5%", "< 15%"
 }
 
-// iPhone models with LiDAR (Pro models from iPhone 12 onwards)
+// iPhone models with LiDAR — ONLY the Pro / Pro Max line carries a LiDAR scanner.
+// (The standard iPhone 13 / 13 mini have no LiDAR and must not be listed here.)
 const LIDAR_IPHONE_MODELS = [
   'iPhone13,3', 'iPhone13,4', // iPhone 12 Pro, Pro Max
   'iPhone14,2', 'iPhone14,3', // iPhone 13 Pro, Pro Max
-  'iPhone14,4', 'iPhone14,5', // iPhone 13 mini, iPhone 13 (no LiDAR but check)
   'iPhone15,2', 'iPhone15,3', // iPhone 14 Pro, Pro Max
   'iPhone16,1', 'iPhone16,2', // iPhone 15 Pro, Pro Max
-  'iPhone17,1', 'iPhone17,2', // iPhone 16 Pro, Pro Max (future)
+  'iPhone17,1', 'iPhone17,2', // iPhone 16 Pro, Pro Max
 ];
 
 // iPad Pro models with LiDAR (2020+)
@@ -49,13 +49,12 @@ const TOF_ANDROID_MODELS = [
 ];
 
 function checkLiDARSupport(modelId: string): boolean {
-  if (Platform.OS === 'ios') {
-    // Check if it's a Pro model
-    return LIDAR_IPHONE_MODELS.some(model => modelId.includes(model)) ||
-           LIDAR_IPAD_MODELS.some(model => modelId.includes(model)) ||
-           modelId.toLowerCase().includes('pro');
-  }
-  return false;
+  if (Platform.OS !== 'ios') return false;
+  // Exact model-id membership. Device.modelId is the hardware identifier (e.g.
+  // 'iPhone15,2'), so the old `modelId.includes('pro')` heuristic never matched a
+  // real device AND, if fed a model NAME instead, would have falsely flagged the
+  // LiDAR-less iPhone 11 Pro / 2018 iPad Pro. Exact match avoids both.
+  return LIDAR_IPHONE_MODELS.includes(modelId) || LIDAR_IPAD_MODELS.includes(modelId);
 }
 
 function checkToFSupport(modelId: string, modelName: string): boolean {
@@ -158,7 +157,9 @@ export function useDeviceCapabilities(): DeviceCapabilities {
 export function getTierDescription(tier: DeviceTier): string {
   switch (tier) {
     case 'lidar':
-      return 'Pro Accuracy (LiDAR)';
+      // This tier covers BOTH iOS LiDAR and Android ToF, so the label stays
+      // sensor-agnostic — a Galaxy S23 Ultra (ToF) is not a LiDAR device.
+      return 'Pro Accuracy (Depth Sensor)';
     case 'standard_ar':
       return 'Standard Accuracy (AR)';
     case 'basic':

--- a/frontend/src/hooks/useDistanceEstimation.ts
+++ b/frontend/src/hooks/useDistanceEstimation.ts
@@ -3,8 +3,8 @@
  *
  * Backs the basic / fallback camera (expo-camera), which has NO access to the depth
  * sensor. Real LiDAR/ToF depth is read by VisionCameraView through the native
- * frame-processor plugin (`__getDepthAtCenter`) and converted to a real-world scale
- * by `estimateImageWidthCm`.
+ * frame-processor plugin (`__getDepthAtCenter`); converting that depth to a real-world
+ * img_w_cm is a separate, not-yet-implemented step (see native-depth-plugin/README.md).
  *
  * Because expo-camera cannot read the depth sensor, this hook does NOT fabricate a
  * distance — it reports `null` unless the user sets one manually — and only drives

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "jest": "^29.7.0",
         "jest-expo": "~54.0.16",
         "react-refresh": "^0.18.0",
-        "react-test-renderer": "^19.2.3",
+        "react-test-renderer": "19.1.0",
         "typescript": "~5.9.2"
       }
     },
@@ -8426,20 +8426,6 @@
         }
       }
     },
-    "node_modules/jest-expo/node_modules/react-test-renderer": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
-      "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-is": "^19.1.0",
-        "scheduler": "^0.26.0"
-      },
-      "peerDependencies": {
-        "react": "^19.1.0"
-      }
-    },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
@@ -12157,25 +12143,18 @@
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.4.tgz",
-      "integrity": "sha512-Ttl5D7Rnmi6JGMUpri4UjB4BAN0FPs4yRDnu2XSsigCWOLm11o8GwRlVsh27ER+4WFqsGtrBuuv5zumUaRCmKw==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "react-is": "^19.2.4",
-        "scheduler": "^0.27.0"
+        "react-is": "^19.1.0",
+        "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.1.0"
       }
-    },
-    "node_modules/react-test-renderer/node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "overrides": {
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "react-test-renderer": "19.1.0"
   }
 }


### PR DESCRIPTION
## What this is

Follow-up fixes after pulling the freshly-merged ARKit / depth **real-world scale** module
(`a0d1283`, the `feat(camera): ARKit plane-raycast scale module` work) and reviewing it. The
native iOS/Android files are reference templates that can't be compiled outside Xcode/Android
Studio — so this PR verifies and hardens everything testable (TypeScript bridge, device tiering,
test infra) and corrects the native templates + docs to be honest, correct starting points.

Verified locally: `tsc --noEmit` clean (only 4 pre-existing, unrelated errors) and **110/111
jest tests pass** (the 1 failure is the pre-existing `useAuthStore` dynamic-import issue).

## Fixes

**Test infrastructure** — `npm test` was broken for every RN-importing test (no jest config wired
`jest-expo`; `react-test-renderer` floated off the pinned `react`). Added `jest.config.js`
(`jest-expo` preset) + `jest.setup.js` (AsyncStorage mock), pinned `react-test-renderer@19.1.0`.

**JS bridge bugs**
- `useDeviceCapabilities`: removed iPhone 13 / 13 mini from the LiDAR list (they have none),
  replaced the dead/over-broad `'pro'` substring with exact model-id matching, added the iPad Pro
  12.9" 5th-gen LiDAR IDs, and relabeled the depth tier so Android ToF devices aren't called "LiDAR".
- `useARScale`: cleanup now resets the start-guard so it can restart after an `enabled` toggle;
  added a 12–90cm plausibility gate so an off-table raycast degrades to the plate fallback instead
  of sending a fabricated scale.
- Added contract tests pinning the "never fabricate scale / degrade to plate fallback" guarantee
  and the device-tier classification.

**Native templates (still device-only, now correct)**
- iOS `GetDepthAtCenterPlugin`: removed the `CMGetAttachment(sampleBuffer, "AVDepthData")` path —
  AVFoundation never attaches depth to a video sample buffer, so as written it could never return a
  distance. Replaced with a timestamp-matched `DepthStore` fed by the `AVCaptureDataOutputSynchronizer`
  delegate (the iOS analogue of the Android `DepthBridge`). Never emit `fx:0` with `hasDepth:true`.
- Android `GetDepthAtCenterPlugin`: decode the real DEPTH16 confidence bits instead of hardcoding
  `0.9` (so the JS `minConfidence` filter is meaningful); same `fx<=0` guard.

**Docs** — corrected `native-depth-plugin/README.md`: removed references to a non-existent
`src/utils/scale.ts` / `estimateImageWidthCm()`, fixed the `DepthResult` contract block and the
verify steps, and replaced the "TS side is fully wired" claim with an accurate "what's wired (the
`route.params.imgWcm` sink) vs what's still a template / unwritten glue" section.

## Honest residual

Building the native modules and writing the capture-screen JS glue (calling `useARScale().measure()`
and pushing `imgWcm` into `route.params`) remain device-side work — now documented accurately rather
than overstated as done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
